### PR TITLE
Add pullQuote to tiramisu renderer

### DIFF
--- a/scripts/tiramisu/lib/visitor.ts
+++ b/scripts/tiramisu/lib/visitor.ts
@@ -323,6 +323,12 @@ const functions: {
 				<p class="text-zinc-400 text-xs">${caption}</p>
 			</div>
 		`;
+	},
+	pullQuote(params) {
+		const content = params.positional.join('');
+		return `<aside class="min-h-10 flex items-center border-l-4 border-neutral-400 pl-4 italic text-neutral-300" >
+      <p>“ ${content}</p>
+    </aside>`;
 	}
 };
 


### PR DESCRIPTION
## ✨ New Feature: `pullQuote` block

This PR introduces a new `pullQuote` block in `.tiramisu` syntax for rendering visually emphasized quotes pulled from the current content. It's designed to highlight key insights and improve page rhythm, without implying external citation.

### Usage

```
pullQuote { Good infrastructure feels like magic. }
```

---

## Context

This decision is based on best practices outlined in [Heydon Pickering’s article on `<blockquote>`](https://heydonworks.com/article/the-blockquote-element/):

- `<blockquote>` is intended for **extended quotations from external sources**
- Proper markup includes a surrounding `<figure>` and a `<figcaption>` for attribution
- **Pull quotes should not use `<blockquote>`** they are decorative and better served by `<aside>`

--- 

## Notes

This PR replaces @Hamedblue1381 's approach in dfdd65ef3998e3cc4a4e5ade2dc80d0ca5d25341. It f keeps the implementation simple, and uses proper semantics.
